### PR TITLE
LIBASPACE-292. Changed base image to "openjdk:8u265-jre"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,16 @@
 
 # This Dockerfile is largely taken from
 # https://github.com/archivesspace/archivesspace/blob/v2.7.1/Dockerfile
+# and https://github.com/dartmouth-dltg/aspace-docker
+FROM openjdk:8u265-jre
 
-FROM ubuntu:18.04 as build_release
+ENV LANG=C.UTF-8
+
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
     apt-get -y install --no-install-recommends \
-      build-essential \
       git \
-      openjdk-8-jre-headless \
       wget \
       unzip && \
       rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Followed example from https://github.com/dartmouth-dltg/aspace-docker
and changed base image from "ubuntu:18.04" to "openjdk:8u265-jre",
which matches the version on the ArchivesSpace server.

This eliminates an error when generating PDFs, as the the Ubuntu
images places an "accessibility.properties" file into the JRE
installation which references a class which is not available. Using
the "openjdk:8u265-jre" image eliminates this problem.

https://issues.umd.edu/browse/LIBASPACE-292