### PR TITLE
LIBASPACE-289. Initial implementation of api-proxy Dockerfile and config

### DIFF
--- a/Dockerfile-api-proxy
+++ b/Dockerfile-api-proxy
@@ -1,0 +1,12 @@
+# Dockerfile for generating the Nginx Docker image used as a reverse proxy
+# for securing the ArchivesSpace API endpoint.
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/aspace-api-proxy:<VERSION> -f Dockerfile-api-proxy .
+#
+# where <VERSION> is the Docker image version to create.
+FROM nginx:1.19.2-alpine
+COPY docker_config/api-proxy/nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 8083

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This repository is intended to replace:
 Docker image
 * Dockerfile-solr - The Dockerfile for creating the Solr instance to use with
 ArchivesSpace
+* Dockerfile-api-proxy - The Dockerfile for creating an Nginx reverse proxy for
+protecting the ArchivesSpace API from anonymous access.
+
+ArchivesSpace
 
 ## Directories
 
@@ -51,3 +55,8 @@ plugins specified in the "archivesspace/config/config.rb" file.
 ### docker_config/solr/
 
 Files/directories used to configure the ArchivesSpace Solr Docker image.
+
+### docker_config/api-proxy/
+
+Contains the Nginx configuration file for reverse proxy that protects the
+ArchivesSpace API endpoints from anonymous access.

--- a/docker_config/api-proxy/nginx.conf
+++ b/docker_config/api-proxy/nginx.conf
@@ -1,0 +1,28 @@
+events {
+  worker_connections 1024;
+}
+
+http {
+  server {
+    listen 8083;
+
+    # Case insensitive regular expression location match to login endpoint
+    # Calls to this endpoint do not require a n"X-ArchivesSpace-Session"
+    # header.
+    location ~* /users/(.*)/login {
+      proxy_pass http://aspace-app:8083/users/$1/login;
+    }
+
+    location / {
+      if ($http_x_archivesspace_session) {
+        # Calls with an "X-ArchivesSpace-Session" header will be passed to the
+        # API. The API is responsible for rejecting "bad" session headers
+        proxy_pass http://aspace-app:8083;
+        break;
+      }
+
+      # Calls without an "X-ArchivesSpace-Session" header return 403 - Forbidden
+      return 403;
+    }
+  }
+}

--- a/docker_config/api-proxy/nginx.conf
+++ b/docker_config/api-proxy/nginx.conf
@@ -6,8 +6,15 @@ http {
   server {
     listen 8083;
 
+    # Return a "ping" response for readiness/liveness checks
+    # This does not require authentication or headers
+    location = /ping {
+      default_type text/html;
+      return 200 "<!DOCTYPE html><h2>api-proxy OK</h2></html>";
+    }
+
     # Case insensitive regular expression location match to login endpoint
-    # Calls to this endpoint do not require a n"X-ArchivesSpace-Session"
+    # Calls to this endpoint do not require an "X-ArchivesSpace-Session"
     # header.
     location ~* /users/(.*)/login {
       proxy_pass http://aspace-app:8083/users/$1/login;
@@ -21,7 +28,8 @@ http {
         break;
       }
 
-      # Calls without an "X-ArchivesSpace-Session" header return 403 - Forbidden
+      # All other calls without an "X-ArchivesSpace-Session" header return
+      # 403 - Forbidden
       return 403;
     }
   }

--- a/docker_config/api-proxy/nginx.conf
+++ b/docker_config/api-proxy/nginx.conf
@@ -17,7 +17,20 @@ http {
     # Calls to this endpoint do not require an "X-ArchivesSpace-Session"
     # header.
     location ~* /users/(.*)/login {
-      proxy_pass http://aspace-app:8083/users/$1/login;
+      # Need to use $is_args$args because we are using regular expression
+      # matching, so any query parameters are not sent automatically.
+      #
+      # Sending the query parameters is necessary because ArchivesSnake
+      # (https://github.com/archivesspace-labs/ArchivesSnake) submits a POST
+      # request for /users/jsmith/login, but puts the parameters in the URL
+      # instead of in the POST message body, so the submitted URL looks like
+      # /users/jsmith/login?password=XXXXX&expiring=False
+      #
+      # While it is arguably bad form for the password to be sent in HTTP
+      # query parameters in this manner (as the password shows up in clear
+      # text in logs, such as the api-proxy log), this is an ArchivesSnake issue
+      # that needs to be fixed in that library.
+      proxy_pass http://aspace-app:8083/users/$1/login$is_args$args;
     }
 
     location / {


### PR DESCRIPTION
An "api-proxy" Dockerfile and configuration using Nginx.

The "api-proxy" container is expected to be inserted between the Nginx
running in Kubernetes and the ArchivesSpace application for requests
to the ArchivesSpace API. The proxy will then reject requests (other
than to the "login" endpoint) that do not have an
"X-ArchivesSpace-Session" header. The ArchivesSpace API will validate
the header.

This should prevent anonymous access to the ArchivesSpace API, while
allowing access to users with ArchivesSpace credentials.

Added a "ping" endpoint to the api-proxy Nginx, to use in
readiness/liveness checks for the pod.

https://issues.umd.edu/browse/LIBASPACE-289