### PR TITLE
LIBASPACE-310. Updated config to use umd-handle for handle minting

### DIFF
--- a/docker_config/archivesspace/archivesspace/config/config.rb
+++ b/docker_config/archivesspace/archivesspace/config/config.rb
@@ -706,17 +706,11 @@ AppConfig[:pui_page_actions_request] = false
 ## Specifies if the fields that show up in csv should be limited to those in search results
 #AppConfig[:limit_csv_fields] = true
 
-# Use UMD_HANDLE_SERVER_URL environment variable for handle server, or default
-# to fedoradev if not defined
-AppConfig[:umd_handle_server_url] = if ENV['UMD_HANDLE_SERVER_URL']
-                                      ENV['UMD_HANDLE_SERVER_URL']
-                                    else
-                                      "https://fedoradev.lib.umd.edu/handle/"
-                                    end
-
-# Handles will be minted with the PUI Url to a resource and its PID.
-# A pid is the resource's identifier, with this namespace prefix
-AppConfig[:umd_handle_namespace] = "archives"
+# umd-handle service environment variables
+AppConfig[:umd_handle_server_url] = ENV['UMD_HANDLE_SERVER_URL']
+AppConfig[:umd_handle_jwt_token] = ENV['UMD_HANDLE_JWT_TOKEN']
+AppConfig[:umd_handle_prefix] = '1903.1'
+AppConfig[:umd_handle_repo] = 'aspace'
 
 AppConfig[:resequence_on_startup] = false # JAW 2015-01-09 set to true for upgrade; false for normal restarts
 

--- a/docker_config/archivesspace/config/plugins
+++ b/docker_config/archivesspace/config/plugins
@@ -10,6 +10,6 @@ https://github.com/hudmol/default_text_for_notes.git 383ec7517bb016a69b118c17517
 https://github.com/hudmol/and_search.git v0.1
 https://github.com/hudmol/digitization_work_order.git v1.7
 https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin.git 20180726 aeon_fulfillment
-https://github.com/umd-lib/aspace-umd-lib-handle-service 1.1.0
+https://github.com/umd-lib/aspace-umd-lib-handle-service 2.0.0
 https://github.com/umd-lib/umd_aeon_fulfillment.git 1.0.1
 https://github.com/harvard-library/aspace-import-excel.git v3.0.4


### PR DESCRIPTION
Updated the configuration to use the "umd-handle" application for
handle minting.

Updated "aspace-umd-lib-handle-service" plugin version in
"docker_config/archivesspace/config/plugins" to 2.0.0, which is the
version that provides the handle minting service using umd-handle.

In docker_config/archivesspace/archivesspace/config/config.rb,
added the environment variables needed to communicate with the
umd-handle service.

https://issues.umd.edu/browse/LIBASPACE-310