### PR TITLE
LIBASPACE-347. Enabled ArchivesSpace "custom report" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ org.jruby.rack.RackInitializationException: Could not find public_suffix-4.0.6 i
 ```
 
 The workaround was to edit [docker_config/archivesspace/scripts/plugins.sh](docker_config/archivesspace/scripts/plugins.sh)
-script) so that the "public_suffix" and "addressable" gems that versions
+script) so that the "public_suffix" and "addressable" gems versions are
 compatible with the stock ArchivesSpace.
 
 As it is likely that the gem versions will slowly change over time, this script
@@ -45,11 +45,44 @@ and responses.
 * Dockerfile - The Dockerfile for creating the UMD-customized ArchivesSpace
 Docker image
 * Dockerfile-solr - The Dockerfile for creating the Solr instance to use with
-ArchivesSpace
+  ArchivesSpace
 * Dockerfile-api-proxy - The Dockerfile for creating an Nginx reverse proxy for
 protecting the ArchivesSpace API from anonymous access.
 
-ArchivesSpace
+## Docker Image Creation for Release
+
+The following steps use the Kubernetes "build" namespace to build the Docker
+images. This enables the steps to used with both newer Apple Silicon laptops and
+older Intel-based Apple laptops.
+
+For information about setting up the Kubernetes "build" namespace, see
+the "Docker Builds in Kuberetes" document in Confluence:
+
+<https://confluence.umd.edu/display/LIB/Docker+Builds+in+Kubernetes>
+
+1) Switch to the Kubernetes "build" namespace:
+
+```bash
+$ kubectl config use-context build
+```
+
+2) Build the Docker images, where \<TAG> is the Docker image tag to use:
+
+```bash
+$ docker buildx build --platform linux/amd64 --builder=kube --push --no-cache -t docker.lib.umd.edu/aspace:<TAG> -f Dockerfile .
+$ docker buildx build --platform linux/amd64 --builder=kube --push --no-cache -t docker.lib.umd.edu/aspace-api-proxy:<TAG> -f Dockerfile-api-proxy .
+$ docker buildx build --platform linux/amd64 --builder=kube --push --no-cache -t docker.lib.umd.edu/aspace-solr:<TAG> -f Dockerfile-solr .
+```
+
+For example, to build all the images using "latest" as the image tag:
+
+```bash
+$ docker buildx build --platform linux/amd64 --builder=kube --push --no-cache -t docker.lib.umd.edu/aspace:latest -f Dockerfile .
+$ docker buildx build --platform linux/amd64 --builder=kube --push --no-cache -t docker.lib.umd.edu/aspace-api-proxy:latest -f Dockerfile-api-proxy .
+$ docker buildx build --platform linux/amd64 --builder=kube --push --no-cache -t docker.lib.umd.edu/aspace-solr:latest -f Dockerfile-solr .
+```
+
+The images will be automatically pushed to the Nexus.
 
 ## Directories
 

--- a/docker_config/archivesspace/archivesspace/config/config.rb
+++ b/docker_config/archivesspace/archivesspace/config/config.rb
@@ -343,8 +343,8 @@ AppConfig[:authentication_sources] = [
 #
 ## option to enable custom reports
 ## USE WITH CAUTION - running custom reports that are too complex may cause ASpace to crash
-#AppConfig[:enable_custom_reports] = false
-#
+AppConfig[:enable_custom_reports] = true
+
 ## Path to system Java -- required when creating PDFs on Windows
 #AppConfig[:path_to_java] = "java"
 #

--- a/docker_config/archivesspace/scripts/plugins.sh
+++ b/docker_config/archivesspace/scripts/plugins.sh
@@ -45,7 +45,7 @@ for gemfile in $(find /apps/aspace/archivesspace/plugins/ -maxdepth 2 -name Gemf
 done
 
 # Replace the following Gem version in the aspace-oauth/Gemfile.lock file, to
-# match those needed by ArchivesSpace. This change is necessary to prevent an
+# match those used by ArchivesSpace. This change is necessary to prevent an
 # error at startup, and needs to be re-evaluated on each ArchivesSpace upgrade
 # and Docker image creation (as the versions in the aspace-oauth Gemfile are
 # not pinned, they may change when a new Docker image is created).
@@ -53,7 +53,7 @@ gemfile_lock='/apps/aspace/archivesspace/plugins/aspace-oauth/Gemfile.lock'
 if [ -f "$gemfile_lock" ]; then
   echo Adjusting gem versions in: "$gemfile_lock"
   sed -i 's/public_suffix (4.0.7)/public_suffix (4.0.6)/g' "$gemfile_lock"
-  sed -i 's/addressable (2.8.1)/addressable (2.8.0)/g' "$gemfile_lock"
+  sed -i 's/addressable (2.8.4)/addressable (2.8.0)/g' "$gemfile_lock"
   sed -i 's/public_suffix (>= 2.0.2, < 6.0)/public_suffix (>= 2.0.2, < 5.0)/g' "$gemfile_lock"
   plugin=$(basename $(dirname $gemfile_lock))
 


### PR DESCRIPTION
At the request of stakeholders, enabled ArchivesSpace
"custom report" functionality.

See https://archivesspace.atlassian.net/wiki/spaces/ArchivesSpaceUserManual/pages/2914877469/Creating+Managing+and+Running+Custom+Reports

Also as part of this issue:

* Replaced addressable 2.8.4. with 2.8.0 in "docker_config/archivesspace/scripts/plugins.sh". This is needed so that ArchivesSpace front-end would run.
* Added additional information about Docker image creation for release to the "README.md" file.

https://umd-dit.atlassian.net/browse/LIBASPACE-347