### PR TITLE
LIBASPACE-348. Added additional web analytics trackers

### DIFF
--- a/docker_config/archivesspace/archivesspace/config/config.rb
+++ b/docker_config/archivesspace/archivesspace/config/config.rb
@@ -804,4 +804,16 @@ AppConfig[:migrate_to_container_management] = false
 AppConfig[:enable_jasper] = true
 AppConfig[:compile_jasper] = true
 
+# Fathom analytics configuration
+AppConfig[:fathom_analytics_data_site] = ENV['FATHOM_ANALYTICS_DATA_SITE']
+
+# Google Analytics configuation
 AppConfig[:public_google_analytics_code] = ENV['PUBLIC_GOOGLE_ANALYTICS_CODE']
+
+# Matomo analytics configuration
+AppConfig[:matomo_analytics_url] = ENV['MATOMO_ANALYTICS_URL']
+AppConfig[:matomo_analytics_site_id] = ENV['MATOMO_ANALYTICS_SITE_ID']
+
+# Plausible.io analytics configuration
+AppConfig[:plausible_io_analytics_data_domain] = ENV['PLAUSIBLE_IO_ANALYTICS_DATA_DOMAIN']
+

--- a/docker_config/archivesspace/config/plugins
+++ b/docker_config/archivesspace/config/plugins
@@ -1,6 +1,6 @@
 # THESE ARE THE VERSIONS OF PLUGINS
 # URL VERSION [NAME]
-https://github.com/umd-lib/umd-lib-aspace-theme.git 1.5.1
+https://github.com/umd-lib/umd-lib-aspace-theme.git 1.6.0
 https://github.com/lyrasis/aspace-oauth.git dd4ac72f8fbedf612a52b58feeeb5ddbc078fc9d
 https://github.com/hudmol/payments_module.git 5fddd44caf2002ba34578e1eead7fb9efb83cdee
 https://github.com/umd-lib/aspace_yale_accessions.git 1.1-umd-0.4


### PR DESCRIPTION
Added analytics tracker configurations for:

* Fathom
* Matomo
* Plausible.io

Updated "umd-lib-aspace-theme" plugin version to 1.6.0, which contains JavaScript scripts to utilize the trackers.

https://umd-dit.atlassian.net/browse/LIBASPACE-348