### PR TITLE
LIBASPACE-352. Removed Google Analytics web tracker config

### DIFF
--- a/docker_config/archivesspace/archivesspace/config/config.rb
+++ b/docker_config/archivesspace/archivesspace/config/config.rb
@@ -804,9 +804,6 @@ AppConfig[:migrate_to_container_management] = false
 AppConfig[:enable_jasper] = true
 AppConfig[:compile_jasper] = true
 
-# Google Analytics configuation
-AppConfig[:public_google_analytics_code] = ENV['PUBLIC_GOOGLE_ANALYTICS_CODE']
-
 # Matomo analytics configuration
 AppConfig[:matomo_analytics_url] = ENV['MATOMO_ANALYTICS_URL']
 AppConfig[:matomo_analytics_site_id] = ENV['MATOMO_ANALYTICS_SITE_ID']

--- a/docker_config/archivesspace/config/plugins
+++ b/docker_config/archivesspace/config/plugins
@@ -1,6 +1,6 @@
 # THESE ARE THE VERSIONS OF PLUGINS
 # URL VERSION [NAME]
-https://github.com/umd-lib/umd-lib-aspace-theme.git 1.7.0
+https://github.com/umd-lib/umd-lib-aspace-theme.git 1.8.0
 https://github.com/lyrasis/aspace-oauth.git dd4ac72f8fbedf612a52b58feeeb5ddbc078fc9d
 https://github.com/hudmol/payments_module.git 5fddd44caf2002ba34578e1eead7fb9efb83cdee
 https://github.com/umd-lib/aspace_yale_accessions.git 1.1-umd-0.4


### PR DESCRIPTION
Removed Google Analytics web tracker configuration, because we are no longer using it. Currently Matomo is the only web analytics tracer in use.

Updated "umd-lib-aspace-theme" plugin to v1.8.0, from which the Google Analytics tracker code was removed.

https://umd-dit.atlassian.net/browse/LIBASPACE-352