### PR TITLE
LIBASPACE-357. Updated "addressable" gem version in plugins workaround

### DIFF
--- a/docker_config/archivesspace/scripts/plugins.sh
+++ b/docker_config/archivesspace/scripts/plugins.sh
@@ -53,7 +53,7 @@ gemfile_lock='/apps/aspace/archivesspace/plugins/aspace-oauth/Gemfile.lock'
 if [ -f "$gemfile_lock" ]; then
   echo Adjusting gem versions in: "$gemfile_lock"
   sed -i 's/public_suffix (4.0.7)/public_suffix (4.0.6)/g' "$gemfile_lock"
-  sed -i 's/addressable (2.8.4)/addressable (2.8.0)/g' "$gemfile_lock"
+  sed -i 's/addressable (2.8.5)/addressable (2.8.0)/g' "$gemfile_lock"
   sed -i 's/public_suffix (>= 2.0.2, < 6.0)/public_suffix (>= 2.0.2, < 5.0)/g' "$gemfile_lock"
   plugin=$(basename $(dirname $gemfile_lock))
 


### PR DESCRIPTION
Modified the workaround in the "plugins.sh" script to properly handle the new "addressable" gem version, and modify it to use the older v2.8.0 expected by
ArchivesSpace.

https://umd-dit.atlassian.net/browse/LIBASPACE-357