### PR TITLE
LIBASPACE-359. PUI homepage update.

### DIFF
--- a/docker_config/archivesspace/config/plugins
+++ b/docker_config/archivesspace/config/plugins
@@ -1,6 +1,6 @@
 # THESE ARE THE VERSIONS OF PLUGINS
 # URL VERSION [NAME]
-https://github.com/umd-lib/umd-lib-aspace-theme.git 1.8.0
+https://github.com/umd-lib/umd-lib-aspace-theme.git 1.9.0
 https://github.com/lyrasis/aspace-oauth.git dd4ac72f8fbedf612a52b58feeeb5ddbc078fc9d
 https://github.com/hudmol/payments_module.git 5fddd44caf2002ba34578e1eead7fb9efb83cdee
 https://github.com/umd-lib/aspace_yale_accessions.git 1.1-umd-0.4

--- a/docker_config/archivesspace/scripts/plugins.sh
+++ b/docker_config/archivesspace/scripts/plugins.sh
@@ -53,7 +53,7 @@ gemfile_lock='/apps/aspace/archivesspace/plugins/aspace-oauth/Gemfile.lock'
 if [ -f "$gemfile_lock" ]; then
   echo Adjusting gem versions in: "$gemfile_lock"
   sed -i 's/public_suffix (4.0.7)/public_suffix (4.0.6)/g' "$gemfile_lock"
-  sed -i 's/addressable (2.8.5)/addressable (2.8.0)/g' "$gemfile_lock"
+  sed -i 's/addressable (2.8.6)/addressable (2.8.0)/g' "$gemfile_lock"
   sed -i 's/public_suffix (>= 2.0.2, < 6.0)/public_suffix (>= 2.0.2, < 5.0)/g' "$gemfile_lock"
   plugin=$(basename $(dirname $gemfile_lock))
 


### PR DESCRIPTION
- Update theme plugin version for the PUI home page update.
- Update addressable gem version to match the current aspace-oauth lock version.

https://umd-dit.atlassian.net/browse/LIBASPACE-359