### PR TITLE
LIBSPACE-360. Updated for ArchivesSpace 3.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
 
 RUN mkdir -p /apps/aspace && \
     cd /apps/aspace && \
-    wget https://github.com/archivesspace/archivesspace/releases/download/v3.3.1/archivesspace-v3.3.1.zip -O archivesspace.zip && \
+    wget https://github.com/archivesspace/archivesspace/releases/download/v3.5.1/archivesspace-v3.5.1.zip -O archivesspace.zip && \
     unzip archivesspace.zip && \
     cd /apps/aspace/archivesspace && \
     wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar -O mysql-connector-java-5.1.39.jar && \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ images. This enables the steps to used with both newer Apple Silicon laptops and
 older Intel-based Apple laptops.
 
 For information about setting up the Kubernetes "build" namespace, see
-the "Docker Builds in Kuberetes" document in Confluence:
+the "Docker Builds in Kubernetes" document in Confluence:
 
 <https://confluence.umd.edu/display/LIB/Docker+Builds+in+Kubernetes>
 

--- a/docker_config/archivesspace/archivesspace/config/config.rb
+++ b/docker_config/archivesspace/archivesspace/config/config.rb
@@ -20,6 +20,7 @@ AppConfig[:db_url] = ENV['ASPACE_DB_URL']
 ## Set the maximum number of database connections used by the application.
 ## Default is derived from the number of indexer threads.
 #AppConfig[:db_max_connections] = proc { 20 + (AppConfig[:indexer_thread_count] * 2) }
+#AppConfig[:db_pool_timeout] = 5 # number of seconds to wait before raising a PoolTimeout error
 #
 ## The ArchivesSpace backend listens on port 8089 by default.  You can set it to
 ## something else below.
@@ -72,14 +73,7 @@ AppConfig[:indexer_log_level] = "info"
 ## Set to true if you have enabled MySQL binary logging
 #AppConfig[:mysql_binlog] = false
 #
-## By default, Solr backups will run at midnight.  See https://crontab.guru/ for
-## information about the schedule syntax.
-#AppConfig[:solr_backup_schedule] = "0 0 * * *"
-## By default no backups. If enabling (by setting > 0) then you must also ensure
-## that AppConfig[:solr_index_directory] is set to the correct path
-#AppConfig[:solr_backup_number_to_keep] = 0
-#AppConfig[:solr_backup_directory] = proc { File.join(AppConfig[:data_directory], "solr_backups") }
-## add default solr params, i.e. use AND for search: AppConfig[:solr_params] = { 'mm' => '100%' }
+## Add default solr params, i.e. use AND for search: AppConfig[:solr_params] = { 'mm' => '100%' }
 ## Another example below sets the boost query value (bq) to boost the relevancy for the query string in the title,
 ## sets the phrase fields parameter (pf) to boost the relevancy for the title when the query terms are in close proximity to
 ## each other, and sets the phrase slop (ps) parameter for the pf parameter to indicate how close the proximity should be
@@ -89,7 +83,7 @@ AppConfig[:indexer_log_level] = "info"
 ##      "ps" => 0,
 ##    }
 ## For more information about solr parameters, please consult the solr documentation
-## here: https://lucene.apache.org/solr/
+## here: https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html
 ## Configuring search operator to be AND by default - ANW-427
 #AppConfig[:solr_params] = { 'q.op' => 'AND' }
 #AppConfig[:solr_verify_checksums] = true
@@ -136,33 +130,8 @@ AppConfig[:plugins] <<  "aspace-umd-lib-handle-service"
 #
 #AppConfig[:oai_proxy_url] = 'http://your-public-oai-url.example.com'
 #
-## DEPRECATED OAI Settings: Moved to database in ANW-674
-## NOTE: As of release 2.5.2, these settings should be set in the Staff User interface
-## To change these settings, select Manage OAI-PMH Settings from the System menu in the staff interface
-## These three settings are at the top of the page in the General Settings section
-## These settings will be removed from the config file completely when version 2.6.0 is released
-#AppConfig[:oai_admin_email] = 'admin@example.com'
-#AppConfig[:oai_record_prefix] = 'oai:archivesspace'
-#AppConfig[:oai_repository_name] = 'ArchivesSpace OAI Provider'
-#
-#
-## In addition to the sets based on level of description, you can define OAI Sets
-## based on repository codes and/or sponsors as follows
-##
-## AppConfig[:oai_sets] = {
-##   'repository_set' => {
-##     :repo_codes => ['hello626'],
-##     :description => "A set of one or more repositories",
-##   },
-##
-##   'sponsor_set' => {
-##     :sponsors => ['The_Sponsor'],
-##     :description => "A set of one or more sponsors",
-##   },
-## }
-#
 #AppConfig[:oai_ead_options] = {}
-## alternate example:  AppConfig[:oai_ead_options] = { :include_daos => true, :use_numbered_c_tags => true }
+## Example: AppConfig[:oai_ead_options] = { :include_daos => true, :use_numbered_c_tags => true, :include_uris => false }
 #
 ###
 ### Other less commonly changed settings are below
@@ -179,10 +148,7 @@ AppConfig[:plugins] <<  "aspace-umd-lib-handle-service"
 #AppConfig[:data_directory] = File.join(Dir.home, "ArchivesSpace")
 #
 AppConfig[:backup_directory] = proc { File.join(AppConfig[:data_directory], "db_backups") }
-## Set the path to the solr index for the external Solr instance.
-## This setting is used by the solr backups configuration but only
-## applies if the solr index directory is accessible to ArchivesSpace.
-#AppConfig[:solr_index_directory] = File.join('', 'var', 'solr', 'data', 'archivesspace', 'data')
+#
 AppConfig[:solr_indexing_frequency_seconds] = 120
 #AppConfig[:solr_facet_limit] = 100
 #
@@ -324,6 +290,8 @@ AppConfig[:authentication_sources] = [
         }
   }
 ]
+## When 'true' restrict authentication attempts to only the source already set for the user
+#AppConfig[:authentication_restricted_by_source] = false # default: allow any source
 #
 #AppConfig[:realtime_index_backlog_ms] = 60000
 #
@@ -344,7 +312,7 @@ AppConfig[:authentication_sources] = [
 ## option to enable custom reports
 ## USE WITH CAUTION - running custom reports that are too complex may cause ASpace to crash
 AppConfig[:enable_custom_reports] = true
-
+#
 ## Path to system Java -- required when creating PDFs on Windows
 #AppConfig[:path_to_java] = "java"
 #
@@ -398,7 +366,11 @@ AppConfig[:enable_custom_reports] = true
 #AppConfig[:show_external_ids] = false
 #
 ## Whether to display archival record identifiers in the frontend largetree container
-#Setting temporarily disabled
+#AppConfig[:display_identifiers_in_largetree_container] = false
+#
+## Allow mixed content in the title fields of resources, archival objects,
+## digital objects, digital object components, and accessions
+#AppConfig[:allow_mixed_content_title_fields] = false
 #
 ## This sets the allowed size of the request/response header that Jetty will accept (
 ## anything bigger gets a 403 error ). Note if you want to jack this size up,
@@ -418,7 +390,7 @@ AppConfig[:enable_custom_reports] = true
 ## Example:
 ## AppConfig[:container_management_barcode_length] = {:system_default => {:min => 5, :max => 10}, 'repo' => {:min => 9, :max => 12}, 'other_repo' => {:min => 9, :max => 9} }
 #
-## :container_management_extent_calculator globally defines the behavior of the exent calculator.
+## :container_management_extent_calculator globally defines the behavior of the extent calculator.
 ## Use :report_volume (true/false) to define whether space should be reported in cubic
 ## or linear dimensions.
 ## Use :unit (:feet, :inches, :meters, :centimeters) to define the unit which the calculator
@@ -533,10 +505,10 @@ AppConfig[:record_inheritance] = {
 ## TODO: Clean up configuration options
 #
 #AppConfig[:pui_search_results_page_size] = 10
-#AppConfig[:pui_branding_img] = 'archivesspace.small.png'
+#AppConfig[:pui_branding_img] = 'ArchivesSpaceLogo.svg'
 #AppConfig[:pui_branding_img_alt_text] = 'ArchivesSpace - a community served by Lyrasis.'
 #
-#AppConfig[:frontend_branding_img] = 'archivesspace/archivesspace.small.png'
+#AppConfig[:frontend_branding_img] = 'archivesspace/ArchivesSpaceLogo.svg'
 #AppConfig[:frontend_branding_img_alt_text] = 'ArchivesSpace - a community served by Lyrasis.'
 #
 #AppConfig[:pui_block_referrer] = true # patron privacy; blocks full 'referrer' when going outside the domain
@@ -576,7 +548,7 @@ AppConfig[:pui_hide][:search_tab] = true
 #AppConfig[:pui_display_deaccessions] = true
 #
 ## Whether to display archival record identifiers in the PUI collection organization tree
-##Setting temporarily disabled
+#AppConfig[:pui_display_identifiers_in_resource_tree] = false
 #
 ##The number of characters to truncate before showing the 'Read More' link on notes
 #AppConfig[:pui_readmore_max_characters] = 450
@@ -627,18 +599,18 @@ AppConfig[:pui_page_actions_request] = false
 #
 ## use the repository record email address for requests (overrides config email)
 #AppConfig[:pui_request_use_repo_email] = false
-#
+#AppConfig[:global_email_from_address] = "noreply@yourdomain.com"
 ## Example sendmail configuration:
-## AppConfig[:pui_email_delivery_method] = :sendmail
-## AppConfig[:pui_email_sendmail_settings] = {
+## AppConfig[:email_delivery_method] = :sendmail
+## AppConfig[:email_sendmail_settings] = {
 ##   location: '/usr/sbin/sendmail',
 ##   arguments: '-i'
 ## }
-##AppConfig[:pui_email_perform_deliveries] = true
-##AppConfig[:pui_email_raise_delivery_errors] = true
+##AppConfig[:email_perform_deliveries] = true
+##AppConfig[:email_raise_delivery_errors] = true
 ## Example SMTP configuration:
-##AppConfig[:pui_email_delivery_method] = :smtp
-##AppConfig[:pui_email_smtp_settings] = {
+##AppConfig[:email_delivery_method] = :smtp
+##AppConfig[:email_smtp_settings] = {
 ##      address:              'smtp.gmail.com',
 ##      port:                 587,
 ##      domain:               'gmail.com',
@@ -647,8 +619,9 @@ AppConfig[:pui_page_actions_request] = false
 ##      authentication:       'plain',
 ##      enable_starttls_auto: true,
 ##}
-##AppConfig[:pui_email_perform_deliveries] = true
-##AppConfig[:pui_email_raise_delivery_errors] = true
+##AppConfig[:email_perform_deliveries] = true
+##AppConfig[:email_raise_delivery_errors] = true
+#
 #
 ## Add page actions via the configuration
 #AppConfig[:pui_page_custom_actions] = []
@@ -787,9 +760,39 @@ AppConfig[:pui_page_actions_request] = false
 ## If enabled, use slugs instead of URIs in finding aid links (856 $u)
 #AppConfig[:use_slug_finding_aid_urls_in_marc_exports] = false
 #
-## Turns on representative file version features - still in development
-#AppConfig[:enable_representative_file_version] = false
-
+## Enables Language Selection in PUI
+#AppConfig[:allow_pui_language_selection] = true
+#
+## How repositories should be sorted in the PUI. Options are :display_string or :position
+#AppConfig[:pui_repositories_sort] = :display_string
+#
+## Set the font used to generate PDFs in the PUI
+#AppConfig[:pui_pdf_font_files] = ["KurintoText-Rg.ttf",
+#                                  "KurintoText-Bd.ttf",
+#                                  "KurintoText-It.ttf",
+#                                  "KurintoTextJP-Rg.ttf",
+#                                  "KurintoTextJP-Bd.ttf",
+#                                  "KurintoTextJP-It.ttf",
+#                                  "KurintoTextKR-Rg.ttf",
+#                                  "KurintoTextKR-Bd.ttf",
+#                                  "KurintoTextKR-It.ttf",
+#                                  "KurintoTextSC-Rg.ttf",
+#                                  "KurintoTextSC-Bd.ttf",
+#                                  "KurintoTextSC-It.ttf",
+#                                  "NotoSerif-Regular.ttf",
+#                                  "NotoSerif-Bold.ttf",
+#                                  "NotoSerif-Italic.ttf"]
+#
+#AppConfig[:pui_pdf_font_name] = "Kurinto Text,Kurinto Text JP,Kurinto Text KR,Kurinto Text SC,Noto Serif"
+#
+#
+#AppConfig[:pui_pdf_paragraph_line_height] = "125%"
+#AppConfig[:pui_pdf_title_line_height] = "140%"
+#
+## Password recovery - requires email configuration
+## See example email configuration above
+#AppConfig[:allow_password_reset] = false
+#
 # umd-handle service environment variables
 AppConfig[:umd_handle_server_url] = ENV['UMD_HANDLE_SERVER_URL']
 AppConfig[:umd_handle_jwt_token] = ENV['UMD_HANDLE_JWT_TOKEN']

--- a/docker_config/archivesspace/archivesspace/plugins/local/public/views/shared/_skipnav.html.erb
+++ b/docker_config/archivesspace/archivesspace/plugins/local/public/views/shared/_skipnav.html.erb
@@ -1,14 +1,19 @@
 <div class="skipnav">
+  <%# UMD Customization %>
   <% if !defined?(@search) %>
     <%= link_to I18n.t('skipnav.main_content'), '#maincontent', :class => 'sr-only sr-only-focusable' %>
   <% end %>
-
-  <% if defined?(@search) && !defined?(@results) %>
-    <%= link_to I18n.t('skipnav.search'), '#search', :class => 'sr-only sr-only-focusable' %>
-  <% elsif defined?(@search) && !defined?(@no_statement) %>
-    <%= link_to I18n.t('skipnav.search'), '#toggleRefineSearch', :class => 'sr-only sr-only-focusable' %>
-  <% end %>
-  <% if defined?(@search) && defined?(@results) %>
-    <%= link_to I18n.t('skipnav.search_results'), '#searchresults', :class => 'sr-only sr-only-focusable' %>
+  <%# End UMD Customizaton %>
+  <% unless ['inventory', 'term'].include?(action_name) || (action_name == 'show' && controller_name != 'repositories') %>
+    <% if defined?(@search) %>
+      <% if defined?(@results) %>
+        <% unless defined?(@no_statement) %>
+          <%= link_to I18n.t('skipnav.search'), '#toggleRefineSearch', :class => 'sr-only sr-only-focusable' %>
+        <% end %>
+        <%= link_to I18n.t('skipnav.search_results'), '#searchresults', :class => 'sr-only sr-only-focusable' %>
+      <% else %>
+        <%= link_to I18n.t('skipnav.search'), '#search', :class => 'sr-only sr-only-focusable' %>
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/docker_config/solr/conf/schema.xml
+++ b/docker_config/solr/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<schema name="archivesspace" version="1.5">
+<schema name="archivesspace" version="1.6">
   <fields>
     <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
     <field name="uri" type="string" indexed="true" stored="true" required="false" multiValued="false" />
@@ -7,10 +7,14 @@
     <field name="pui_parent_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
     <field name="four_part_id" type="text_general" indexed="true" stored="true" multiValued="false" />
     <field name="title" type="text_general" indexed="true" stored="true" multiValued="false" />
+    <field name="title_ws" type="text_ws" indexed="true" stored="true" multiValued="false" />
+    <copyField source="title" dest="title_ws" />
     <field name="types" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="primary_type" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="repository" type="string" indexed="true" stored="true" multiValued="false" />
-    <field name="fullrecord" type="text_general" indexed="true" stored="false" multiValued="false" />
+    <field name="fullrecord" type="text_general" indexed="true" stored="false" multiValued="true" />
+    <field name="fullrecord_published" type="text_general" indexed="true" stored="false" multiValued="true" />
+    <copyField source="fullrecord_published" dest="fullrecord" />
     <field name="suppressed" type="boolean" indexed="true" stored="true" multiValued="false" />
     <field name="publish" type="boolean" indexed="true" stored="true" multiValued="false" />
     <field name="external_id" type="string" indexed="true" stored="true" multiValued="true" />
@@ -25,7 +29,11 @@
     <field name="agent_uris" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="published_agent_uris" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="related_agent_uris" type="string" indexed="true" stored="true" multiValued="true" />
-    <field name="notes" type="text_general" indexed="true" stored="true" multiValued="false" />
+    <!-- why are notes stored? (public app gets them from json for display) probably to support highlighting a long time ago -->
+    <!-- https://github.com/archivesspace/archivesspace/commit/87b7270f11456e0db329c45404333a1ce68419b8 -->
+    <field name="notes" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <field name="notes_published" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <copyField source="notes_published" dest="notes" />
     <field name="years" type="int" indexed="true" stored="false" multiValued="true" />
     <field name="year_sort" type="sort_string" indexed="true" stored="false" multiValued="false" />
     <field name="dates" type="text_general" indexed="true" stored="true" multiValued="true" />
@@ -39,6 +47,8 @@
     <field name="langcode" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="accession_date_year" type="int" indexed="true" stored="true" multiValued="false" />
     <field name="identifier" type="sort_icu" indexed="true" stored="true" multiValued="false" />
+    <field name="identifier_ws" type="text_ws" indexed="true" stored="true" multiValued="false" />
+    <copyField source="identifier" dest="identifier_ws" />
     <field name="acquisition_type" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="accession_date" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="resource_type" type="string" indexed="true" stored="true" multiValued="false" />
@@ -74,6 +84,7 @@
     <field name="classification_uris" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="location_uris" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="linked_record_uris" type="string" indexed="true" stored="true" multiValued="true" />
+    <field name="linked_record_titles" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="digital_object_uris" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="linked_instance_uris" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="related_accession_uris" type="string" indexed="true" stored="true" multiValued="true" />
@@ -155,6 +166,7 @@
     <dynamicField name="*_u_sortdate" type="date" indexed="true" stored="false" multiValued="false" />
     <dynamicField name="*_u_ssortdate" type="date" indexed="true" stored="true" multiValued="false" />
     <dynamicField name="*_relator_sort" type="sort_string" indexed="true" stored="true" multiValued="false" />
+    <dynamicField name="*_int_sort" type="int" indexed="true" stored="false" multiValued="false" />
   </fields>
   <uniqueKey>id</uniqueKey>
   <types>
@@ -175,6 +187,7 @@
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.LowerCaseFilterFactory" />
       </analyzer>
     </fieldType>
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">

--- a/docker_config/solr/conf/solrconfig.xml
+++ b/docker_config/solr/conf/solrconfig.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
-  <lib dir="/opt/solr/dist/" regex="solr-analysis-extras.*\.jar" />
-  <lib dir="/opt/solr/contrib/analysis-extras/lucene-libs" regex="lucene-analyzers-icu-.*\.jar" />
-  <lib dir="/opt/solr/contrib/analysis-extras/lib/" regex="icu4j-*.*\.jar" />
+  <lib dir="${solr.install.dir}/dist/" regex="solr-analysis-extras.*\.jar" />
+  <lib dir="${solr.install.dir}/contrib/analysis-extras/lucene-libs" regex="lucene-analyzers-icu-.*\.jar" />
+  <lib dir="${solr.install.dir}/contrib/analysis-extras/lib/" regex="icu4j-*.*\.jar" />
   <schemaFactory class="ClassicIndexSchemaFactory"/>
   <luceneMatchVersion>8.10</luceneMatchVersion>
   <dataDir>${solr.data.dir:}</dataDir>
@@ -37,7 +37,6 @@
       <int name="rows">10</int>
       <str name="df">fullrecord</str>
       <str name="pf">four_part_id^50</str>
-      <str name="qf">title^25 four_part_id^50 fullrecord</str>
       <str name="bq">primary_type:resource^100</str>
       <str name="bq">primary_type:accession^100</str>
       <str name="bq">primary_type:subject^50</str>
@@ -57,4 +56,7 @@
     <defaultQuery>*:*</defaultQuery>
   </admin>
   <requestHandler name="/admin/luke" class="org.apache.solr.handler.admin.LukeRequestHandler" />
+  <indexConfig>
+    <lockType>${solr.lock.type:native}</lockType>
+  </indexConfig>
 </config>

--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -33,10 +33,10 @@ $ cd archivesspace
 $ git checkout <VERSION_TAG>
 ```
 
-For example, to switch to v3.3.1, use:
+For example, to switch to v3.5.1, use:
 
 ```bash
-$ git checkout v3.3.1
+$ git checkout v3.5.1
 ```
 
 1.4) Retrieve the ArchivesSpace Docker images:
@@ -70,13 +70,10 @@ OpenJDK v11.0.16.1:
 ```text
 bundler:
      [echo] Fetching gems for ../backend/Gemfile
-     [java] /Users/dsteelma/Junk4/aspace_template_fix/archivesspace/build/gems/gems/bundler-2.1.4/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb:203: warning: Process#getrlimit not supported on this platform
-     [java] git version 2.38.0
-     [java] warning: thread "Ruby-0-Thread-1: uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/open3.rb:200" terminated with exception (report_on_exception is true):
-     [java] NotImplementedError: waitpid unsupported or native support failed to load; see https://github.com/jruby/jruby/wiki/Native-Libraries
-     [java]   waitpid at org/jruby/RubyProcess.java:936
-     [java] NotImplementedError: waitpid unsupported or native support failed to load; see https://github.com/jruby/jruby/wiki/Native-Libraries
-     [java]   waitpid at org/jruby/RubyProcess.java:936
+     [java] Retrying fetcher due to error (2/4): NameError uninitialized constant Dir::FileUtils
+     [java] Fetching gem metadata from https://rubygems.org/.
+     [java] Retrying fetcher due to error (3/4): NameError uninitialized constant Dir::FileUtils
+     [java] Retrying fetcher due to error (4/4): NameError uninitialized constant Dir::FileUtils
 ```
 
 I was able to get the command to work using Java 8, specifically:
@@ -101,7 +98,8 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.301-b09, mixed mode)
 ```
 
 It is unclear why this error occurs, but it appears to be intermittent, and
-re-running the command will usually work (may take several tries).
+re-running the command will usually work (may take several tries, sometimes 5 or
+6, usually making progress and failing differently each time).
 
 ---
 
@@ -239,6 +237,10 @@ At least for the "umd-lib-aspace-theme" plugin, changes can be made directly in
 the "plugins/umd-lib-aspace-theme" directories, and ArchivesSpace will
 immediately pick up the changes without having to be restarted.
 
+**Note:** Development on the plugins can be done directly in the cloned
+repositories in the "plugins" directory, with the usual Rails hot-reload
+support.
+
 ## 3. Sample Data
 
 ### Loading EAD Sample Data
@@ -278,10 +280,23 @@ The "New Background Job - Import Data" form will be displayed.
 to upload. Left-click the "Start Job" button. The "Import Job" page will be
 displayed.
 
-3.7) Once the job has completed, go to the front-end public interface
-(<http://localhost:3001/>). Left-click the "Libraries" link on the
-application home page. The resulting page should display the
-"UMD Test Repository", and indicate that it has 3 collections.
+3.7) Once the job has completed, the "Amoss, William L. papers" collection
+will be published, but the other two collection will be unpublished:
+
+* Archives of the Atlantic Monthly
+* Louis Auchincloss papers
+
+To publish these collections, for each unpublished collection:
+
+3.7.1) Select "Browse | Resources". The "Resources" page will be displayed.
+
+3.7.2) Select the "Edit" button for an unpublished collection, then on the
+resulting page, left-click the "Publish All" button, and then select
+"Publish All" in the confirmation dialog.
+
+3.8) Go to the front-end public interface (<http://localhost:3001/>). Left-click
+the "Libraries" link on the application home page. The resulting page should
+display the "UMD Test Repository", and indicate that it has 3 collections.
 
 ### Destroying Sample Data
 
@@ -301,3 +316,11 @@ From <https://archivesspace.github.io/tech-docs/development/dev.html>:
 > ```
 >
 > Which will first delete then migrate the database.
+
+Note that this should be followed by commands to reset the Solr database, and
+re-run the database migrations:
+
+```zsh
+$ ./build/run solr:reset
+$ ./build/run db:migrate
+```

--- a/docs/resources/ead/README.md
+++ b/docs/resources/ead/README.md
@@ -1,3 +1,3 @@
 # docs/resource/ead/README.md
 
-This directory contais EAD files for testing data imports.
+This directory contains EAD files for testing data imports.


### PR DESCRIPTION
* Updated the files for ArchivesSpace v3.5.1, largely by
   comparing to the corresponding files in the
   archivesspace-v3.5.1.zip release distribution.

* In "solrconfig.xml" replaced the hard-coded`/opt/solr/dist/`
  with `${solr.install.dir}` as in the stock file.

* Updated the "Dockerfile" to download ArchivesSpace v3.5.1

https://umd-dit.atlassian.net/browse/LIBASPACE-360