### PR TITLE
LIBASPACE-379. Workaround for gem version error on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,38 @@ This repository is intended to replace:
 
 See [docs/DevelopmentSetup.md](docs/DevelopmentSetup.md).
 
+## ArchivesSpace Upgrade/Docker Image Creation
+
+When creating a new Docker image based on to ArchivesSpace v3.5.1 upgrade,
+there was a gem version conflict between the stock ArchivesSpace and the
+transitive dependencies of the "digitization_work_order" plugin gem.
+
+The conflict manifested itself by the ArchivesSpace server throwing the
+following error on startup:
+
+```text
+INFO: An exception happened during JRuby-Rack startup
+Could not find rubyzip-2.3.2 in any of the sources
+...
+
+WARNING: ERROR: initialization failed
+org.jruby.rack.RackInitializationException: Could not find public_suffix-4.0.6 in any of the sources
+...
+```
+
+The workaround was to edit the
+[docker_config/archivesspace/scripts/plugins.sh](docker_config/archivesspace/scripts/plugins.sh)
+script) so that the "rubyzip" gem uses a version that is compatible with the
+stock ArchivesSpace.
+
+As it is likely that the gem versions will slowly change over time, this script
+should be reviewed whenever a new ArchivesSpace upgrade performed, or new
+production Docker images are created.
+
+This issue was also discussed on the ArchivesSpace mailing list, see
+<https://groups.google.com/a/lyrasislists.org/g/archivesspace_users_group_archived/c/j_12U3N8vd8>
+and responses.
+
 ## Dockerfiles
 
 * Dockerfile - The Dockerfile for creating the UMD-customized ArchivesSpace

--- a/docker_config/archivesspace/scripts/plugins.sh
+++ b/docker_config/archivesspace/scripts/plugins.sh
@@ -43,3 +43,18 @@ for gemfile in $(find /apps/aspace/archivesspace/plugins/ -maxdepth 2 -name Gemf
     echo Initializing plugin: "$plugin"
     /apps/aspace/archivesspace/scripts/initialize-plugin.sh "$plugin"
 done
+
+# Replace the following Gem version in the digitization_work_order/Gemfile.lock
+# file, to match those used by ArchivesSpace. This change is necessary to
+# prevent an error at startup, and needs to be re-evaluated on each
+# ArchivesSpace upgrade and Docker image creation (as the versions in the
+# digitization_work_order Gemfile are not pinned, they may change when a new
+# Docker image is created).
+gemfile_lock='/apps/aspace/archivesspace/plugins/digitization_work_order/Gemfile.lock'
+if [ -f "$gemfile_lock" ]; then
+  echo Adjusting gem versions in: "$gemfile_lock"
+  sed -i 's/rubyzip (2.4.1)/rubyzip (2.3.2)/g' "$gemfile_lock"
+  plugin=$(basename $(dirname $gemfile_lock))
+
+  /apps/aspace/archivesspace/scripts/initialize-plugin.sh "$plugin"
+fi


### PR DESCRIPTION
Modifies the "rubyzip" gem version in the
"digitization_work_order/Gemfile.lock" file to prevent the following error at startup:

```
INFO: An exception happened during JRuby-Rack startup
Could not find rubyzip-2.3.2 in any of the sources
...
WARNING: ERROR: initialization failed
org.jruby.rack.RackInitializationException: Could not find rubyzip-2.3.2 in any of the sources
...
```

This seems to be a re-emergence of the “gem version” issue we saw in ArchivesSpace 3.3.1, see

* https://umd-dit.atlassian.net/browse/LIBASPACE-333
* https://umd-dit.atlassian.net/browse/LIBASPACE-357

this time caused by the “hudmol/digitization_work_order” dependency, which has a transitive dependency on an unconstrained “rubyzip” gem via the its use of the “write_xlsx” gem.

Updated the "README.md" file.

https://umd-dit.atlassian.net/browse/LIBASPACE-379