### PR TITLE
LIBASPACE-412. Added "docs/TestPlan.md" document

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ application, and provides Dockerfiles for creating the Docker images used by the
 [umd-lib/k8s-aspace](https://github.com/umd-lib/k8s-aspace) Kubernetes
 configuration.
 
-This repository is intended to replace:
+This repository replaces:
 
 * [umd-lib/aspace-docker](https://github.com/umd-lib/aspace-docker)
 * [https://bitbucket.org/umd-lib/aspace-env](https://bitbucket.org/umd-lib/aspace-env)
@@ -33,6 +33,9 @@ customizes the stock ArchivesSpace:
 
 * [docs/Customizations.md](docs/Customizations.md)
 * [docs/DockerfileCustomizations.md](docs/DockerfileCustomizations.md)
+
+See [docs/TestPlan.md] for links to information on verifying the customizations
+provided by the UMD plugins.
 
 ## Dockerfiles
 

--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -264,7 +264,7 @@ displayed.
 4.7) Once the job has completed, the "Amoss, William L. papers" collection
 will be published, but the other two collection will be unpublished:
 
-* Archives of the Atlantic Monthly
+* Atlantic Monthly records
 * Louis Auchincloss papers
 
 To publish these collections, for each unpublished collection:

--- a/docs/TestPlan.md
+++ b/docs/TestPlan.md
@@ -1,0 +1,41 @@
+# Test Plan
+
+## Introduction
+
+This document outlines a basic test plan for verifying UMD customizations
+to stock ArchivesSpace functionality.
+
+The intention is to provide basic assurance that the UMD customizations are
+functional, and guard against regressions.
+
+**This document is not intended to be an exhaustive test plan, nor should it
+replace stakeholder testing.**
+
+## Testing Resources
+
+UMD customizations are provided in the form of ArchivesSpace plugins, each in
+its own GitHub repository. Each plugin provides its own verification steps
+for testing.
+
+The following is a suggested order for verifying the plugin functionality:
+
+1) [umd-lib/umd-lib-aspace-theme/docs/PublicInterfaceCustomizations.md][1]
+
+2) [umd-lib/umd-lib-aspace-theme/docs/StaffInterfaceCustomizations.md][2]
+
+3) [umd-lib/aspace-custom/docs/Customizations.md][3]
+
+4) [umd-lib/aspace_yale_accessions/docs/Customizations.md][4]
+
+5) [umd-lib/aspace-umd-lib-handle-service/README.md][5]
+
+6) [umd-lib/umd_aeon_fulfillment/docs/Customizations.md][6]
+
+---
+
+[1]: https://github.com/umd-lib/umd-lib-aspace-theme/blob/main/docs/PublicInterfaceCustomizations.md
+[2]: https://github.com/umd-lib/umd-lib-aspace-theme/blob/main/docs/StaffInterfaceCustomizations.md
+[3]: https://github.com/umd-lib/aspace-custom/blob/main/docs/Customizations.md
+[4]: https://github.com/umd-lib/aspace_yale_accessions/blob/main/docs/Customizations.md
+[5]: https://github.com/umd-lib/aspace-umd-lib-handle-service/blob/main/README.md
+[6]: https://github.com/umd-lib/umd_aeon_fulfillment/blob/main/docs/Customizations.md

--- a/docs/resources/ead/0057.LIT_20171121_135754_UTC__ead.xml
+++ b/docs/resources/ead/0057.LIT_20171121_135754_UTC__ead.xml
@@ -7,7 +7,7 @@
     <repository>
       <corpname>Special Collections and University Archives</corpname>
     </repository>
-    <unittitle>Archives of the Atlantic Monthly</unittitle>
+    <unittitle>Atlantic Monthly records</unittitle>
     <origination audience="internal" label="creator">
       <corpname role="dnr" source="ingest">Atlantic Monthly</corpname>
     </origination>
@@ -27,7 +27,7 @@
 <p>The Archives of the Atlantic Monthly Press came to the University of Maryland Libraries through the efforts of Peter Davison in January 2002. In 1986 the then-owner of the <title render="italic">Atlantic Monthly</title>, Morton Zuckerman, sold the book division of the Atlantic Monthly Company to Carl Navarre, who in turn sold the press to Morgan Entrekin in 1991. Entrekin tired of warehousing the archives and subsequently returned the materials to <title render="italic">Atlantic Monthly</title> at the request of its staff. Since their return, Davison has placed these archival materials with institutions housing the major archives of the individual authors. Davison was director of the Atlantic Monthly Press from 1964 to 1979 and senior editor from 1979 to 1985. From 1964 until Porter's death, Davison was responsible for maintaining relations with Porter and Atlantic Monthly Press. He has also edited and published books with Houghton Mifflin under the Peter Davison Books imprint (1985-1998). In 2002, he was the poetry editor of the <title render="italic">Atlantic Monthly</title>.</p>  </acqinfo>
   <prefercite id="aspace_9f67bfa5d235957265192b50b290c1f3">
     <head>Preferred Citation</head>
-<p>Archives of the Atlantic Monthly, Special Collections, University of Maryland Libraries.</p>  </prefercite>
+<p>Atlantic Monthly records, Special Collections, University of Maryland Libraries.</p>  </prefercite>
   <processinfo id="aspace_b76e1a4a98412f826c7ae9c2375936c2">
     <head>Processing Information</head>
 <p>Staples were removed from the materials, and newspaper clippings were photocopied onto acid-free paper. The original chronological arrangement of the correspondence was retained. The collection was placed in acid-free folders and housed in an acid-free box.</p>  </processinfo>


### PR DESCRIPTION
Added "docs/TestPlan.md" document with links to information on verifying the functionality of each of the UMD ArchivesSpace plugins.

Updated the "README.md" document with a link to the test plan.

https://umd-dit.atlassian.net/browse/LIBASPACE-412