### PR TITLE
LIBASPACE-420. Modify Nginx configuration to allow DELETE REST requests

### DIFF
--- a/docker_config/api-proxy/nginx.conf
+++ b/docker_config/api-proxy/nginx.conf
@@ -34,16 +34,15 @@ http {
     }
 
     location / {
-      if ($http_x_archivesspace_session) {
-        # Calls with an "X-ArchivesSpace-Session" header will be passed to the
-        # API. The API is responsible for rejecting "bad" session headers
-        proxy_pass http://aspace-app:8083;
-        break;
+      # Reject immediately if no session header, before hitting upstream
+      if ($http_x_archivesspace_session = "") {
+        return 403;
       }
 
-      # All other calls without an "X-ArchivesSpace-Session" header return
-      # 403 - Forbidden
-      return 403;
+      # Calls with an "X-ArchivesSpace-Session" header will be passed to the
+      # API. The API is responsible for rejecting "bad" session headers
+      proxy_http_version 1.1;
+      proxy_pass http://aspace-app:8083;
     }
   }
 


### PR DESCRIPTION
Modified the Ngnix configuration to always use the `HTTP/1.1` protocol version when making upstream requests to ArchivesSpace REST API, by adding

```
proxy_http_version 1.1;
```

to the reverse proxy configuration. This is necessary because, by default Nginx uses the `HTTP/1.0` protocol when proxying to the upstream and Jetty can behave oddly/more strictly in that case. In this particular instance, Jetty was returning an HTTP 400 response for DELETE requests.

Also refactored the reverse proxy configuration to move the "proxy_pass" out of the "if" block. This was based on Perplexity indicating that having an "if" with a "proxy_pass" in the block is a known anti-pattern, specifically:

> Nginx's infamous "if is evil" problem means that when you use
> proxy_pass inside an if block, the effective location context is
> effectively a new implicit location, and the request method can get
> mangled or reset to GET in some Nginx versions/builds.

While this wasn't the cause of the problem in this case, it seemed worthwhile to do the refactor.

Co-authored-by: Perplexity AI <noreply@perplexity.ai>
https://umd-dit.atlassian.net/browse/LIBASPACE-420